### PR TITLE
Support HelmReleases with separate registry entry

### DIFF
--- a/kubeyaml.py
+++ b/kubeyaml.py
@@ -206,7 +206,7 @@ def set_fluxhelmrelease_container(manifest, container, replace):
                 im = replace
             elif len(segments) == 2:
                 domainComponent = '([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])'
-                domain = 'localhost|(%s([.]%s)+)(:[0-9]+)?' % (domainComponent, domainComponent)
+                domain = '(localhost|(%s([.]%s)+))(:[0-9]+)?' % (domainComponent, domainComponent)
                 if re.fullmatch(domain, segments[0]):
                     reg = segments[0]
                     im = segments[1]

--- a/kubeyaml.py
+++ b/kubeyaml.py
@@ -168,7 +168,7 @@ def mappings(values):
 def fluxhelmrelease_containers(manifest):
     def get_image(values):
         image = values['image']
-        if isinstance(image, collections.Mapping) and 'repository' in image and 'tag' in image:
+        if isinstance(image, collections.Mapping) and 'repository' in image:
             values = image
             image = image['repository']
         if 'registry' in values and values['registry'] != '':

--- a/test_kubeyaml.py
+++ b/test_kubeyaml.py
@@ -36,8 +36,9 @@ dns_labels = strats.from_regex(
 host_components = strats.from_regex(r"^[a-zA-Z0-9]([a-zA-Z0-9-]{0,125}[a-zA-Z0-9])?$").map(strip)
 port_numbers = strats.integers(min_value=1, max_value=32767)
 
-hostnames_without_port = strats.builds('.'.join,
-    strats.lists(elements=host_components, min_size=1, max_size=6))
+hostnames_without_port = strats.just('localhost') | \
+                         strats.builds('.'.join,
+                            strats.lists(elements=host_components, min_size=2, max_size=6))
 
 hostnames_with_port = strats.builds(
     lambda h, p: str(h)+':'+str(p),
@@ -54,11 +55,8 @@ image_separators = strats.just('.')  | \
 
 host_segments = strats.just([]) | hostnames.map(lambda x: [x])
 
-# This results in realistic image refs, we use a min_size of two for
-# test cases that make use of a hostname as the Docker image ref spec
-# has a limitation on images with a hostname that requires it to have
-# at least two elements if the hostname is not localhost.
-exact_image_names = strats.builds('/'.join, strats.lists(elements=image_components(), min_size=2, max_size=6))
+# This results in realistic image refs
+exact_image_names = strats.builds('/'.join, strats.lists(elements=image_components(), min_size=1, max_size=6))
 # This is somewhat faster, if we don't care about having realistic
 # image refs
 sloppy_image_names = strats.text(string.ascii_letters + '-/_', min_size=1, max_size=255).map(strip)

--- a/test_kubeyaml.py
+++ b/test_kubeyaml.py
@@ -62,10 +62,13 @@ exact_image_names = strats.builds('/'.join, strats.lists(elements=image_componen
 # This is somewhat faster, if we don't care about having realistic
 # image refs
 sloppy_image_names = strats.text(string.ascii_letters + '-/_', min_size=1, max_size=255).map(strip)
+sloppy_image_names_with_host = strats.builds(
+    lambda host, name: host + '/' + name,
+    hostnames, sloppy_image_names)
 image_tags = strats.from_regex(r"^[a-z][\w.-]{0,127}$").map(strip)
 
 # NB select the default image name format to use
-image_names = sloppy_image_names
+image_names = sloppy_image_names | sloppy_image_names_with_host
 
 images_with_tag = strats.builds(
     lambda name, tag: name + ':' + tag,
@@ -207,10 +210,11 @@ image_registry_values = strats.builds(lambda r, n, t: {'registry': r, 'image': '
 image_registry_tag_values = strats.builds(lambda r, n, t: {'registry': r, 'image': n, 'tag': t, '_containers': [{kubeyaml.FHR_CONTAINER: '%s/%s:%s' % (r, n, t)}]}, hostnames, exact_image_names, image_tags)
 image_obj_values = strats.builds(lambda n, t: {'image': {'repository': n, 'tag': t}, '_containers': [{kubeyaml.FHR_CONTAINER: '%s:%s' % (n, t)}]}, image_names, image_tags)
 image_obj_repository_values = (image_names | images_with_tag).map(lambda image: {'image': {'repository': image}, '_containers': [{kubeyaml.FHR_CONTAINER: image}]})
-image_obj_registry_values = strats.builds(lambda r, n, t: {'image': {'registry': r, 'repository': n, 'tag': t}, '_containers': [{kubeyaml.FHR_CONTAINER: '%s/%s:%s' % (r, n, t)}]}, hostnames, exact_image_names, image_tags)
+image_obj_registry_tag_values = strats.builds(lambda r, n, t: {'image': {'registry': r, 'repository': n, 'tag': t}, '_containers': [{kubeyaml.FHR_CONTAINER: '%s/%s:%s' % (r, n, t)}]}, hostnames, exact_image_names, image_tags)
+image_obj_registry_repository_values = strats.builds(lambda r, n, t: {'image': {'registry': r, 'repository': '%s:%s' % (n, t)}, '_containers': [{kubeyaml.FHR_CONTAINER: '%s/%s:%s' % (r, n, t)}]}, hostnames, exact_image_names, image_tags)
 
 # One of the above
-toplevel_image_values = image_only_values | image_tag_values | image_registry_values | image_registry_tag_values | image_obj_values | image_obj_registry_values
+toplevel_image_values = image_only_values | image_tag_values | image_registry_values | image_registry_tag_values | image_obj_values | image_obj_registry_tag_values | image_obj_registry_repository_values
 # Some of the above, in fields
 named_image_values = strats.dictionaries(keys=dns_labels, values=toplevel_image_values).map(lift_containers)
 # Combo of top-level image, and images in subfields

--- a/test_kubeyaml.py
+++ b/test_kubeyaml.py
@@ -11,6 +11,17 @@ import collections
 def strip(s):
     return s.strip()
 
+@composite
+def image_components(draw):
+    bits = draw(strats.lists(
+        elements=strats.text(alphabet=alphanumerics, min_size=1),
+        min_size=1, max_size=16))
+    s = bits[0]
+    for c in bits[1:]:
+        sep = draw(image_separators)
+        s = s + sep + c
+    return s
+
 # I only want things that will got on one line, so make my own printable alphabet
 printable = string.ascii_letters + string.digits + string.punctuation + ' '
 
@@ -41,31 +52,20 @@ image_separators = strats.just('.')  | \
                    strats.just('__') | \
                    strats.integers(min_value=1, max_value=5).map(lambda n: '-' * n)
 
-image_tags = strats.from_regex(r"^[a-z][\w.-]{0,127}$").map(strip)
-
-@composite
-def image_components(draw):
-    bits = draw(strats.lists(
-        elements=strats.text(alphabet=alphanumerics, min_size=1),
-        min_size=1, max_size=16))
-    s = bits[0]
-    for c in bits[1:]:
-        sep = draw(image_separators)
-        s = s + sep + c
-    return s
-
 host_segments = strats.just([]) | hostnames.map(lambda x: [x])
-image_names = strats.builds(lambda host, cs: '/'.join(host + cs),
-                            host_segments,
-                            strats.lists(elements=image_components(),
-                                         min_size=1, max_size=6))
 
+# This results in realistic image refs, we use a min_size of two for
+# test cases that make use of a hostname as the Docker image ref spec
+# has a limitation on images with a hostname that requires it to have
+# at least two elements if the hostname is not localhost.
+exact_image_names = strats.builds('/'.join, strats.lists(elements=image_components(), min_size=2, max_size=6))
 # This is somewhat faster, if we don't care about having realistic
 # image refs
-sloppy_image_names = strats.text(string.ascii_letters + '-/_', min_size=1, max_size=255)
-# NB override image_names
-image_names = strats.builds(lambda host, cs: '/'.join(host + [cs]),
-                            host_segments, sloppy_image_names)
+sloppy_image_names = strats.text(string.ascii_letters + '-/_', min_size=1, max_size=255).map(strip)
+image_tags = strats.from_regex(r"^[a-z][\w.-]{0,127}$").map(strip)
+
+# NB select the default image name format to use
+image_names = sloppy_image_names
 
 images_with_tag = strats.builds(
     lambda name, tag: name + ':' + tag,
@@ -203,9 +203,14 @@ def combine_containers(toplevel, subfields):
 # {'foo': {'image': 'foobar', 'tag': 'v1'}, '_containers': [{'foo': 'foobar:v1'}]}
 image_only_values = (image_names | images_with_tag).map(lambda image: {'image': image, '_containers': [{kubeyaml.FHR_CONTAINER: image}]})
 image_tag_values = strats.builds(lambda n, t: {'image': n, 'tag': t, '_containers': [{kubeyaml.FHR_CONTAINER: '%s:%s' % (n, t)}]}, image_names, image_tags)
+image_registry_values = strats.builds(lambda r, n, t: {'registry': r, 'image': '%s:%s' % (n, t), '_containers': [{kubeyaml.FHR_CONTAINER: '%s/%s:%s' % (r, n, t)}]}, hostnames, exact_image_names, image_tags)
+image_registry_tag_values = strats.builds(lambda r, n, t: {'registry': r, 'image': n, 'tag': t, '_containers': [{kubeyaml.FHR_CONTAINER: '%s/%s:%s' % (r, n, t)}]}, hostnames, exact_image_names, image_tags)
 image_obj_values = strats.builds(lambda n, t: {'image': {'repository': n, 'tag': t}, '_containers': [{kubeyaml.FHR_CONTAINER: '%s:%s' % (n, t)}]}, image_names, image_tags)
+image_obj_repository_values = (image_names | images_with_tag).map(lambda image: {'image': {'repository': image}, '_containers': [{kubeyaml.FHR_CONTAINER: image}]})
+image_obj_registry_values = strats.builds(lambda r, n, t: {'image': {'registry': r, 'repository': n, 'tag': t}, '_containers': [{kubeyaml.FHR_CONTAINER: '%s/%s:%s' % (r, n, t)}]}, hostnames, exact_image_names, image_tags)
+
 # One of the above
-toplevel_image_values = image_only_values | image_tag_values | image_obj_values
+toplevel_image_values = image_only_values | image_tag_values | image_registry_values | image_registry_tag_values | image_obj_values | image_obj_registry_values
 # Some of the above, in fields
 named_image_values = strats.dictionaries(keys=dns_labels, values=toplevel_image_values).map(lift_containers)
 # Combo of top-level image, and images in subfields

--- a/test_kubeyaml.py
+++ b/test_kubeyaml.py
@@ -299,6 +299,7 @@ def test_match_self(man):
     spec = Spec.from_resource(man)
     assert kubeyaml.match_manifest(spec, man)
 
+@settings(suppress_health_check=[HealthCheck.too_slow])
 @given(workload_resources, strats.data())
 def test_find_container(man, data):
     cs = kubeyaml.containers(man)


### PR DESCRIPTION
This PR adds support for the following image formats in `HelmRelease`s:

```yaml
# Top level
registry: docker.io
image: foo/bar
tag: v1

# As a 'container' mapping
container:
  registry: docker.io
  image: foo/bar
  tag: v1

# Also valid
container:
  registry: docker.io
  image: foo/bar:v1

# In an image object
image:
  registry: docker.io
  repository: foo/bar
```

Required for: https://github.com/weaveworks/flux/pull/2149