### PR TITLE
Update Alpine '3.6' -> '3.9'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN /pyinstaller/pyinstaller.sh --noconfirm --clean kubeyaml.py
 #RUN ls -R /src/
 #RUN cat /src/warn*.txt
 
-FROM alpine:3.6
+FROM alpine:3.9
 
 ENTRYPOINT ["/usr/lib/kubeyaml/kubeyaml"]
 COPY --from=pyinstaller /home/kubeyaml/dist/kubeyaml /usr/lib/kubeyaml


### PR DESCRIPTION
To resolve `dlopen: Error relocating /usr/lib/kubeyaml/libpython3.6m.so.1.0: getrandom: symbol not found` error.