### PR TITLE
Add `set` command to set the value of dot notation path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ clean:
 	touch $@
 
 test:
-	pytest --hypothesis-show-statistics
+	pytest --hypothesis-show-statistics test_*

--- a/test_kubeyaml_annotate.py
+++ b/test_kubeyaml_annotate.py
@@ -1,0 +1,26 @@
+import kubeyaml
+from test_kubeyaml import resource, Spec
+
+def test_update_annotations():
+    man = resource('Deployment', 'default', 'foo')
+    man['metadata']['annotations'] = {
+        'fluxcd.io/automated': 'true',
+        'fluxcd.io/locked': 'false',
+    }
+
+    automated = ['fluxcd.io/automated', 'false'] # should be altered
+    unlocked = ['fluxcd.io/locked', ''] # should be removed
+    new = ['fluxcd.io/tag.foo', 'glob:*'] # should be added
+
+    args = Spec.from_resource(man)
+    args.notes = [automated, unlocked, new]
+
+    man1 = None
+    for out in kubeyaml.update_annotations(args, [man]):
+        man1 = out
+
+    assert man1 is not None
+    assert man1['metadata']['annotations'] == {
+        automated[0]: automated[1],
+        new[0]: new[1],
+    }

--- a/test_kubeyaml_set.py
+++ b/test_kubeyaml_set.py
@@ -1,0 +1,60 @@
+import copy
+import kubeyaml
+from test_kubeyaml import resource, Spec, check_structure
+
+def test_set_paths():
+    man = resource('HelmRelease', 'default', 'release')
+    man['spec'] = {
+        'chart': {
+            'repository': 'https://kubernetes-charts.storage.googleapis.com/',
+            'name': 'sample',
+            'version': '0.1',
+        },
+        'values': {
+            'image': {
+                'repository': 'image/sample',
+                'tag': '0.1',
+            }
+        }
+    }
+
+    image, tag = 'other/sample', '0.2'
+
+    args = Spec.from_resource(man)
+    args.paths = [['spec.values.image.tag', tag], ['spec.values.image.repository', image]]
+
+    man1 = copy.deepcopy(man)
+    man2 = None
+    for out in kubeyaml.set_paths(args, [man]):
+        man2 = out
+
+    assert man2 is not None
+    assert man2['spec']['values']['image']['repository'] == image
+    assert man2['spec']['values']['image']['tag'] == tag
+    check_structure(man1, man2)
+
+def test_set_paths_raise_on_non_plain_values():
+    man = resource('HelmRelease', 'default', 'release')
+    man['spec'] = {
+        'chart': {
+            'repository': 'https://kubernetes-charts.storage.googleapis.com/',
+        },
+    }
+
+    args = Spec.from_resource(man)
+    args.paths = [['spec.chart', 'invalid']]
+
+    man1 = copy.deepcopy(man)
+    man2 = None
+
+    try:
+        for out in kubeyaml.set_paths(args, [man]):
+            man2 = out
+    except kubeyaml.UnresolvablePath:
+        pass
+    else:
+        assert False, "UnresolvablePath not raised"
+
+    assert man2 is not None
+    assert man1 == man2
+    check_structure(man1, man2)


### PR DESCRIPTION
This commit adds a new `set` command, which can be used to update
one or multiple values in a resource by their dot notation path(s).

In case a given path does not resolve into a value, or the resolved
value is not a plain value, the path is collected and later returned
in an error, when all given paths have been attempted.