### PR TITLE
fix: handle empty content among manifests separators

### DIFF
--- a/kubeyaml.py
+++ b/kubeyaml.py
@@ -153,6 +153,8 @@ def set_paths(spec, docs):
         raise NotFound()
 
 def manifests(doc):
+    if doc == None:
+        return collections.OrderedDict()
     if doc['kind'].endswith('List'):
         for m in doc['items']:
             yield m


### PR DESCRIPTION
Summary:
need to handle empty content among manifests separators.

Steps to reproduce:

feed the input to kubeyaml
``` yaml
apiVersion: apps/v1
kind: Deployment
# with other kubernetes manifests like deployment ....
---
# comment only
---
# comment only
---
kind: Service
apiVersion: v1
# with other kubernetes manifests content ....
```
`cat input.yaml | docker run --rm -i kubeyaml image --namespace staging --kind Deployment --name queue-daemon-default --container fluentd --image test2`

Expected output:
no error

Actual output:
error with message
```
Traceback (most recent call last):
  File "kubeyaml.py", line 313, in <module>
  File "kubeyaml.py", line 306, in main
  File "kubeyaml.py", line 77, in apply_to_yaml
  File "site-packages/ruamel/yaml/main.py", line 462, in dump_all
  File "kubeyaml.py", line 84, in update_image
  File "kubeyaml.py", line 158, in manifests
TypeError: 'NoneType' object is not subscriptable
```

Version
0.7.0, 7fc6ab8519bfa27a3a3684a5b17dd030330d8bda